### PR TITLE
typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ trigger a validation error in CI:
 $ retext-mapbox-standard bad.md
 bad.md
   1:19-1:22  warning  OSM is jargon, use OpenStreetMap instead
-  1:40-1:46  warning  Mapbox is styled Mapbox
+  1:40-1:46  warning  MapBox is styled Mapbox
   2:40-2:47  warning  geoJSON should be styled GeoJSON
   4:50-4:55  warning  `crazy` may be insensitive, use `rude`, `mean`, `disgusting`, `vile`, `person with symptoms of mental illness`, `person with mental illness`, `person with symptoms of a mental disorder`, `person with a mental disorder` instead
 Source: http://ncdj.org/style-guide/


### PR DESCRIPTION
There should be a typo, but the output of **bad.md** is wrongly correct.