### PR TITLE
Add 'BI' as an exception to account for Power BI

### DIFF
--- a/lib/standard.js
+++ b/lib/standard.js
@@ -11,6 +11,7 @@ var stripLiquid = require('./strip_liquid');
 
 var equalityConfig = {
     ignore: [
+        'bi', // Microsoft Power BI
         'disabled', // technical
         'masterpiece', // not offensive enough
         'host' // technical


### PR DESCRIPTION
I'm writing a new guide for the Microsoft Visual in Power BI, and the tests are failing on the word "BI". (Error message is: warning  `BI` may be insensitive, use `Bisexual` instead) 

We're unlikely to use "bi" in any scenario other than in referring to Power BI, so I think it's fine for us to add this as an exception!

@lyzidiamond Let me know what you think. 

cc @colleenmcginnis 